### PR TITLE
get resource links via secure connection

### DIFF
--- a/device-simulator/patches/devsim.diff
+++ b/device-simulator/patches/devsim.diff
@@ -1,25 +1,3 @@
-diff --git a/api/cloud/oc_cloud_resource.c b/api/cloud/oc_cloud_resource.c
-index c6b36d7..09b14c5 100644
---- a/api/cloud/oc_cloud_resource.c
-+++ b/api/cloud/oc_cloud_resource.c
-@@ -144,7 +144,7 @@ post_cloud(oc_request_t *request, oc_interface_mask_t interface,
-   }
-   OC_DBG("POST request received");
-   (void)interface;
--
-+/*
-   switch (ctx->store.cps) {
-   case OC_CPS_UNINITIALIZED:
-   case OC_CPS_READYTOREGISTER:
-@@ -155,7 +155,7 @@ post_cloud(oc_request_t *request, oc_interface_mask_t interface,
-     return;
-   }
-   }
--
-+*/
-   char *cps;
-   size_t cps_len = 0;
-   if (oc_rep_get_string(request->request_payload, "cps", &cps, &cps_len)) {
 diff --git a/apps/cloud_server.c b/apps/cloud_server.c
 index 6edd644..ceaff87 100644
 --- a/apps/cloud_server.c

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-ocf/cloud v0.0.0-20200722070446-3773fbf08dcb
-	github.com/go-ocf/go-coap/v2 v2.0.4-0.20200728125043-f38b86f047a7
+	github.com/go-ocf/go-coap/v2 v2.0.4-0.20200729140542-f80fe6477c94
 	github.com/go-ocf/kit v0.0.0-20200728130040-4aebdb6982bc
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/go-ocf/go-coap/v2 v2.0.4-0.20200728093524-65e8ccbe4cd6 h1:R8rJXhYGIcS
 github.com/go-ocf/go-coap/v2 v2.0.4-0.20200728093524-65e8ccbe4cd6/go.mod h1:X9wVKcaOSx7wBxKcvrWgMQq1R2DNeA7NBLW2osIb8TM=
 github.com/go-ocf/go-coap/v2 v2.0.4-0.20200728125043-f38b86f047a7 h1:AKdudU3gkKJ+eoESnMWcdyH43liYFXmwva8EMlbmOqc=
 github.com/go-ocf/go-coap/v2 v2.0.4-0.20200728125043-f38b86f047a7/go.mod h1:X9wVKcaOSx7wBxKcvrWgMQq1R2DNeA7NBLW2osIb8TM=
+github.com/go-ocf/go-coap/v2 v2.0.4-0.20200729140542-f80fe6477c94 h1:mocTf5g6SGVnUm+JtRf2n5gmLaqHfy2TcO2MXfIQyDU=
+github.com/go-ocf/go-coap/v2 v2.0.4-0.20200729140542-f80fe6477c94/go.mod h1:6iBZI5Ifx3FEr1ustRr2fx1sAnN2hEFzir7But7JdA0=
 github.com/go-ocf/grpc-gateway v0.0.0-20191029150757-8ed2b7d67a67/go.mod h1:GuVJZHmSz7KGATOk0tqLPkgBJq2H12hZnG74CTJXOtI=
 github.com/go-ocf/grpc-gateway v0.0.0-20191128115804-9c2e8f77af08/go.mod h1:XBVeqnt2JEx0Z6SLEdjnjQ53jEpbAvcx+/CAC43eAb4=
 github.com/go-ocf/grpc-gateway v0.0.0-20200206140756-f2e98d630ed6/go.mod h1:UmskFCqe00ISEBHTZJbWIeyvvHcIuVsS/5c5FFEHF8s=

--- a/local/core/getDevice.go
+++ b/local/core/getDevice.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-ocf/sdk/schema"
 )
 
+// According to Device2Cloud spec the CoAPCloudConf Resource shall expose only secure Endpoints (e.g. CoAPS); see the ISO/IEC 30118-1:2018, clause 10.
+// You have to be secure to talk to it so we try to load device links via secure endpoints if it is possible.
 func patchDeviceLinks(ctx context.Context, d *Device, dlinks schema.ResourceLinks) (*Device, schema.ResourceLinks, error) {
 	isSecure, err := d.IsSecured(ctx, dlinks)
 	if err != nil {

--- a/local/core/getDevice.go
+++ b/local/core/getDevice.go
@@ -9,12 +9,34 @@ import (
 	"github.com/go-ocf/sdk/schema"
 )
 
+func patchDeviceLinks(ctx context.Context, d *Device, dlinks schema.ResourceLinks) (*Device, schema.ResourceLinks, error) {
+	isSecure, err := d.IsSecured(ctx, dlinks)
+	if err != nil {
+		defer d.Close(ctx)
+		return nil, nil, fmt.Errorf("cannot determine whether device %s is secured: %w", d.DeviceID(), err)
+	}
+	if !isSecure {
+		return d, dlinks, nil
+	}
+	dlink, err := GetResourceLink(dlinks, "/oic/d")
+	if err != nil {
+		defer d.Close(ctx)
+		return nil, nil, fmt.Errorf("cannot read device link for secure device %s: %w", d.DeviceID(), err)
+	}
+	dlinks, err = d.GetResourceLinks(ctx, dlink.GetEndpoints())
+	if err != nil {
+		defer d.Close(ctx)
+		return nil, nil, fmt.Errorf("cannot get resource links for secure device %s: %w", d.DeviceID(), err)
+	}
+	return d, dlinks, nil
+}
+
 // GetDevice performs a multicast and returns a device object if the device responds.
 func (c *Client) GetDevice(ctx context.Context, deviceID string) (*Device, schema.ResourceLinks, error) {
-	ctx, cancel := context.WithCancel(ctx)
+	findCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	multicastConn := DialDiscoveryAddresses(ctx, c.discoveryConfiguration, c.errFunc)
+	multicastConn := DialDiscoveryAddresses(findCtx, c.discoveryConfiguration, c.errFunc)
 	defer func() {
 		for _, conn := range multicastConn {
 			conn.Close()
@@ -22,7 +44,7 @@ func (c *Client) GetDevice(ctx context.Context, deviceID string) (*Device, schem
 	}()
 
 	h := newDeviceHandler(c.getDeviceConfiguration(), deviceID, cancel)
-	err := DiscoverDevices(ctx, multicastConn, h)
+	err := DiscoverDevices(findCtx, multicastConn, h)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get the device %s: %w", deviceID, err)
 	}
@@ -30,7 +52,8 @@ func (c *Client) GetDevice(ctx context.Context, deviceID string) (*Device, schem
 	if d == nil {
 		return nil, nil, fmt.Errorf("no response from the device %s", deviceID)
 	}
-	return d, dlinks, nil
+
+	return patchDeviceLinks(ctx, d, dlinks)
 }
 
 func newDeviceHandler(

--- a/local/core/getDevices.go
+++ b/local/core/getDevices.go
@@ -62,6 +62,12 @@ func (h *discoveryHandler) Handle(ctx context.Context, conn *client.ClientConn, 
 	}
 	d := NewDevice(h.deviceCfg, deviceID, link.ResourceTypes)
 
+	d, links, err = patchDeviceLinks(ctx, d, links)
+	if err != nil {
+		h.handler.Error(err)
+		return
+	}
+
 	h.handler.Handle(ctx, d, links)
 }
 

--- a/local/core/getEndpoints.go
+++ b/local/core/getEndpoints.go
@@ -1,0 +1,130 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-ocf/go-coap/v2/udp/client"
+	"github.com/go-ocf/kit/net"
+	"github.com/go-ocf/kit/net/coap"
+	"github.com/go-ocf/sdk/schema"
+)
+
+func (d *Device) findBestClient() (net.Addr, *coap.ClientCloseHandler, error) {
+	var client *coap.ClientCloseHandler
+	var addr net.Addr
+	var err error
+
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	for key, conn := range d.conn {
+		ep := schema.Endpoint{
+			URI: key,
+		}
+		addr, err = ep.GetAddr()
+		if err != nil {
+			continue
+		}
+		switch schema.Scheme(addr.GetScheme()) {
+		case schema.TCPSecureScheme:
+			return addr, conn, nil
+		case schema.UDPSecureScheme:
+			return addr, conn, nil
+		default:
+			client = conn
+		}
+	}
+	if client == nil {
+		return addr, nil, fmt.Errorf("cannot find connection to device")
+	}
+	return addr, client, nil
+}
+
+func newDeviceDiscoveryHandler(
+	deviceID string,
+	cancel context.CancelFunc,
+) *deviceDiscoveryHandler {
+	return &deviceDiscoveryHandler{
+		deviceID: deviceID,
+		cancel:   cancel,
+	}
+}
+
+type deviceDiscoveryHandler struct {
+	deviceID string
+	cancel   context.CancelFunc
+
+	lock  sync.Mutex
+	links schema.ResourceLinks
+	ok    bool
+}
+
+func (h *deviceDiscoveryHandler) ResourceLinks() (schema.ResourceLinks, bool) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	return h.links, h.ok
+}
+
+func (h *deviceDiscoveryHandler) Handle(ctx context.Context, conn *client.ClientConn, links schema.ResourceLinks) {
+	defer conn.Close()
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	addr, err := net.Parse(string(schema.UDPScheme), conn.RemoteAddr())
+	if err != nil {
+		return
+	}
+	link, err := GetResourceLink(links, "/oic/d")
+	if err != nil {
+		return
+	}
+	if h.ok || link.GetDeviceID() != h.deviceID {
+		return
+	}
+	h.links = links.PatchEndpoint(addr)
+	h.ok = true
+	h.cancel()
+}
+
+func (h *deviceDiscoveryHandler) Error(err error) {
+}
+
+func (d *Device) GetEndpoints(ctx context.Context) ([]schema.Endpoint, error) {
+	addr, client, err := d.findBestClient()
+	if err == nil {
+		links, err := getResourceLinks(ctx, addr, client, coap.WithResourceType(schema.DeviceResourceType))
+		if err != nil {
+			return nil, fmt.Errorf("cannot get resource links for %v: %w", d.DeviceID(), err)
+		}
+		dlink, err := GetResourceLink(links, "/oic/d")
+		if err != nil {
+			return nil, fmt.Errorf("cannot read device link for device %s: %w", d.DeviceID(), err)
+		}
+		return dlink.Endpoints, nil
+	}
+	resLinksCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var links schema.ResourceLinks
+	var ok bool
+
+	multicastConn := DialDiscoveryAddresses(ctx, d.cfg.discoveryConfiguration, d.cfg.errFunc)
+	defer func() {
+		for _, conn := range multicastConn {
+			conn.Close()
+		}
+	}()
+
+	h := newDeviceDiscoveryHandler(d.DeviceID(), cancel)
+	DiscoverDevices(resLinksCtx, multicastConn, h, coap.WithResourceType(schema.DeviceResourceType))
+	links, ok = h.ResourceLinks()
+	if ok {
+		dlink, err := GetResourceLink(links, "/oic/d")
+		if err != nil {
+			return nil, fmt.Errorf("cannot read device link for device %s: %w", d.DeviceID(), err)
+		}
+		return dlink.Endpoints, nil
+	}
+
+	return nil, fmt.Errorf("device %v not found", d.DeviceID())
+}

--- a/local/core/getEndpoints_test.go
+++ b/local/core/getEndpoints_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-ocf/sdk/local/core"
 	"github.com/go-ocf/sdk/test"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestDevice_GetResourceLinks(t *testing.T) {
+func TestDevice_GetEndpoints(t *testing.T) {
 	deviceID := test.MustFindDeviceByName(TestDeviceName)
 	secureDeviceID := test.MustFindDeviceByName(test.TestSecureDeviceName)
 	type args struct {
@@ -45,13 +44,11 @@ func TestDevice_GetResourceLinks(t *testing.T) {
 			timeout, cancelTimeout := context.WithTimeout(context.Background(), 3*time.Second)
 			defer cancelTimeout()
 
-			device, links, err := c.GetDevice(timeout, deviceId)
+			device, _, err := c.GetDevice(timeout, deviceId)
 			require.NoError(err)
 			defer device.Close(timeout)
 
-			dlink, err := core.GetResourceLink(links, "/oic/d")
-			require.NoError(err)
-			got, err := device.GetResourceLinks(timeout, dlink.GetEndpoints())
+			got, err := device.GetEndpoints(timeout)
 			if tt.wantErr {
 				require.Error(err)
 			} else {

--- a/local/core/getResource.go
+++ b/local/core/getResource.go
@@ -29,7 +29,7 @@ func (d *Device) GetResourceWithCodec(
 	options ...coap.OptionFunc,
 ) error {
 	options = append(options, coap.WithAccept(codec.ContentFormat()))
-	client, err := d.connectToEndpoints(ctx, link.GetEndpoints())
+	_, client, err := d.connectToEndpoints(ctx, link.GetEndpoints())
 	if err != nil {
 		return fmt.Errorf("cannot get resource %v: %w", link.Href, err)
 	}

--- a/local/core/getResourceLinks.go
+++ b/local/core/getResourceLinks.go
@@ -3,92 +3,12 @@ package core
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/go-ocf/go-coap/v2/message"
-	"github.com/go-ocf/go-coap/v2/udp/client"
 	"github.com/go-ocf/kit/net"
 	"github.com/go-ocf/kit/net/coap"
 	"github.com/go-ocf/sdk/schema"
 )
-
-func (d *Device) findBestClient() (net.Addr, *coap.ClientCloseHandler, error) {
-	var client *coap.ClientCloseHandler
-	var addr net.Addr
-	var err error
-
-	d.lock.Lock()
-	defer d.lock.Unlock()
-	for key, conn := range d.conn {
-		ep := schema.Endpoint{
-			URI: key,
-		}
-		addr, err = ep.GetAddr()
-		if err != nil {
-			continue
-		}
-		switch schema.Scheme(addr.GetScheme()) {
-		case schema.TCPSecureScheme:
-			return addr, conn, nil
-		case schema.UDPSecureScheme:
-			return addr, conn, nil
-		default:
-			client = conn
-		}
-	}
-	if client == nil {
-		return addr, nil, fmt.Errorf("cannot find connection to device")
-	}
-	return addr, client, nil
-}
-
-func newDeviceDiscoveryHandler(
-	deviceID string,
-	cancel context.CancelFunc,
-) *deviceDiscoveryHandler {
-	return &deviceDiscoveryHandler{
-		deviceID: deviceID,
-		cancel:   cancel,
-	}
-}
-
-type deviceDiscoveryHandler struct {
-	deviceID string
-	cancel   context.CancelFunc
-
-	lock  sync.Mutex
-	links schema.ResourceLinks
-	ok    bool
-}
-
-func (h *deviceDiscoveryHandler) ResourceLinks() (schema.ResourceLinks, bool) {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	return h.links, h.ok
-}
-
-func (h *deviceDiscoveryHandler) Handle(ctx context.Context, conn *client.ClientConn, links schema.ResourceLinks) {
-	defer conn.Close()
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	addr, err := net.Parse(string(schema.UDPScheme), conn.RemoteAddr())
-	if err != nil {
-		return
-	}
-	link, err := GetResourceLink(links, "/oic/d")
-	if err != nil {
-		return
-	}
-	if h.ok || link.GetDeviceID() != h.deviceID {
-		return
-	}
-	h.links = links.PatchEndpoint(addr)
-	h.ok = true
-	h.cancel()
-}
-
-func (h *deviceDiscoveryHandler) Error(err error) {
-}
 
 func getResourceLinks(ctx context.Context, addr net.Addr, client *coap.ClientCloseHandler, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
 	options = append(options, coap.WithAccept(message.AppOcfCbor))
@@ -103,37 +23,16 @@ func getResourceLinks(ctx context.Context, addr net.Addr, client *coap.ClientClo
 	return links.PatchEndpoint(addr), nil
 }
 
-func (d *Device) GetResourceLinks(ctx context.Context, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
-	addr, client, err := d.findBestClient()
-	if err == nil {
-		links, err := getResourceLinks(ctx, addr, client, options...)
-		if err != nil {
-			return links, fmt.Errorf("cannot get resource links for %v: %w", d.DeviceID(), err)
-		}
-		return links, nil
+func (d *Device) GetResourceLinks(ctx context.Context, endpoints []schema.Endpoint, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
+	addr, client, err := d.connectToEndpoints(ctx, endpoints)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get resource links for %v with endpoints %+v: %w", d.DeviceID(), endpoints, err)
 	}
-	resLinksCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	var links schema.ResourceLinks
-	var ok bool
-
-	multicastConn := DialDiscoveryAddresses(ctx, d.cfg.discoveryConfiguration, d.cfg.errFunc)
-	defer func() {
-		for _, conn := range multicastConn {
-			conn.Close()
-		}
-	}()
-
-	h := newDeviceDiscoveryHandler(d.DeviceID(), cancel)
-	DiscoverDevices(resLinksCtx, multicastConn, h, options...)
-	links, ok = h.ResourceLinks()
-	if ok {
-		return links, nil
+	links, err := getResourceLinks(ctx, addr, client, options...)
+	if err != nil {
+		return links, fmt.Errorf("cannot get resource links for %v: %w", d.DeviceID(), err)
 	}
-
-	return nil, fmt.Errorf("device %v not found", d.DeviceID())
-
+	return links, nil
 }
 
 func GetResourceLink(links schema.ResourceLinks, href string) (schema.ResourceLink, error) {

--- a/local/core/observeResource.go
+++ b/local/core/observeResource.go
@@ -120,7 +120,7 @@ func (d *Device) observeResource(
 	options ...kitNetCoap.OptionFunc,
 ) (observationID string, _ error) {
 
-	client, err := d.connectToEndpoints(ctx, link.GetEndpoints())
+	_, client, err := d.connectToEndpoints(ctx, link.GetEndpoints())
 
 	if err != nil {
 		return "", fmt.Errorf("cannot observe resource %v: %w", link.Href, err)

--- a/local/core/ownDevice.go
+++ b/local/core/ownDevice.go
@@ -404,6 +404,15 @@ func (d *Device) Own(
 
 	tlsClient.Close()
 
+	dlink, err := GetResourceLink(links, "/oic/d")
+	if err != nil {
+		return fmt.Errorf(errMsg, fmt.Errorf("cannot get device link: %w", err))
+	}
+	links, err = d.GetResourceLinks(ctx, dlink.Endpoints)
+	if err != nil {
+		return fmt.Errorf(errMsg, fmt.Errorf("cannot get resource links: %w", err))
+	}
+
 	/*pstat set owner of resource*/
 	err = d.setProvisionResourceOwner(ctx, links, sdkID)
 	if err != nil {

--- a/local/core/updateResource.go
+++ b/local/core/updateResource.go
@@ -28,7 +28,7 @@ func (d *Device) UpdateResourceWithCodec(
 	response interface{},
 	options ...kitNetCoap.OptionFunc,
 ) error {
-	client, err := d.connectToEndpoints(ctx, link.GetEndpoints())
+	_, client, err := d.connectToEndpoints(ctx, link.GetEndpoints())
 	if err != nil {
 		return fmt.Errorf("cannot update resource %v: %w", link.Href, err)
 	}

--- a/local/getDevice.go
+++ b/local/getDevice.go
@@ -14,7 +14,13 @@ func (c *Client) GetRefDevice(
 ) (*RefDevice, schema.ResourceLinks, error) {
 	refDev, ok := c.deviceCache.GetDevice(ctx, deviceID)
 	if ok {
-		links, err := refDev.GetResourceLinks(ctx)
+		endpoints, err := refDev.GetEndpoints(ctx)
+		if err != nil {
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		links, err := refDev.GetResourceLinks(ctx, endpoints)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/local/offboardDevice.go
+++ b/local/offboardDevice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 )
 
+// OffboardDevice for unsecure device it reset attributes, for secure device it calls Disown.
 func (c *Client) OffboardDevice(ctx context.Context, deviceID string) error {
 	d, links, err := c.GetRefDevice(ctx, deviceID)
 	if err != nil {
@@ -11,16 +12,12 @@ func (c *Client) OffboardDevice(ctx context.Context, deviceID string) error {
 	}
 	defer d.Release(ctx)
 
-	// TODO remove workaround
+	ok, err := d.IsSecured(ctx, links)
+	if err != nil {
+		return err
+	}
+	if ok {
+		return d.Disown(ctx, links)
+	}
 	return setCloudResource(ctx, links, d, "", "", "", "")
-	/*
-		ok, err := d.IsSecured(ctx, links)
-		if err != nil {
-			return err
-		}
-		if ok {
-			return d.Offboard(ctx)
-		}
-		return d.OffboardInsecured(ctx)
-	*/
 }

--- a/local/offboardDevice_test.go
+++ b/local/offboardDevice_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClient_OffboardDevice(t *testing.T) {
-	deviceID := test.MustFindDeviceByName(test.TestDeviceName)
+	deviceID := test.MustFindDeviceByName(test.TestSecureDeviceName)
 	type args struct {
 		token    string
 		deviceID string
@@ -29,7 +29,8 @@ func TestClient_OffboardDevice(t *testing.T) {
 		},
 	}
 
-	c := NewTestClient()
+	c, err := NewTestSecureClient()
+	require.NoError(t, err)
 	defer func() {
 		err := c.Close(context.Background())
 		require.NoError(t, err)

--- a/local/onboardDevice_test.go
+++ b/local/onboardDevice_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClient_OnboardDevice(t *testing.T) {
-	deviceID := test.MustFindDeviceByName(test.TestDeviceName)
+	deviceID := test.MustFindDeviceByName(test.TestSecureDeviceName)
 	type args struct {
 		token                 string
 		deviceID              string
@@ -31,7 +31,7 @@ func TestClient_OnboardDevice(t *testing.T) {
 				deviceID:              deviceID,
 				authorizationProvider: "authorizationProvider",
 				authorizationCode:     "authorizationCode",
-				cloudURL:              "coap+tcp://test:5684",
+				cloudURL:              "coaps+tcp://test:5684",
 				cloudID:               "cloudID",
 			},
 		},
@@ -48,7 +48,10 @@ func TestClient_OnboardDevice(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 			defer cancel()
-			err := c.OnboardDevice(ctx, tt.args.deviceID, tt.args.authorizationProvider, tt.args.cloudURL, tt.args.authorizationCode, tt.args.cloudID)
+			err := c.OwnDevice(ctx, deviceID)
+			require.NoError(t, err)
+			defer c.DisownDevice(ctx, deviceID)
+			err = c.OnboardDevice(ctx, tt.args.deviceID, tt.args.authorizationProvider, tt.args.cloudURL, tt.args.authorizationCode, tt.args.cloudID)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {

--- a/local/refDevice.go
+++ b/local/refDevice.go
@@ -122,8 +122,12 @@ func (d *RefDevice) Provision(ctx context.Context, links schema.ResourceLinks) (
 	return d.Device().Provision(ctx, links)
 }
 
-func (d *RefDevice) GetResourceLinks(ctx context.Context, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
-	return d.Device().GetResourceLinks(ctx, options...)
+func (d *RefDevice) GetEndpoints(ctx context.Context) ([]schema.Endpoint, error) {
+	return d.Device().GetEndpoints(ctx)
+}
+
+func (d *RefDevice) GetResourceLinks(ctx context.Context, endpoints []schema.Endpoint, options ...coap.OptionFunc) (schema.ResourceLinks, error) {
+	return d.Device().GetResourceLinks(ctx, endpoints, options...)
 }
 
 func (d *RefDevice) FactoryReset(ctx context.Context, links schema.ResourceLinks) error {


### PR DESCRIPTION
Current implementation of SDK expected that cloud resource is visible under unsecure connection. But according to Device2Cloud spec this is not true:
The CoAPCloudConf Resource shall expose only secure Endpoints (e.g. CoAPS); see the ISO/IEC 30118-1:2018, clause 10.
You have to be secure to talk to it. The only time we allow unsecure in any circumstance is initial MCAST discovery.